### PR TITLE
WMKNBN-8805: Wait for test run creation/completion to finish

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
   - Methods to create or finish a test run are now blocking
   - Selenium actions will no longer go missing
 
+## [0.53] - 2023-12-15
+### Fixes
+- Add missing DevicePropertyName enum values
+
 ## [0.52] - 2023-09-26
 ### Fixes
 - Compatibility change for webmate release 2023.4.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.54] - 2024-01-16
+### Fixes
+- Wait for test run creation/completion to finish
+  - Methods to create or finish a test run are now blocking
+  - Selenium actions will no longer go missing
+
 ## [0.52] - 2023-09-26
 ### Fixes
 - Compatibility change for webmate release 2023.4.0

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This release is also distributed via Maven Central. Just include the following d
 <dependency>
     <groupId>com.testfabrik.webmate.sdk</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>0.53</version>
+    <version>0.54</version>
 </dependency>
 ```
 
@@ -39,7 +39,7 @@ After that, you can include the SDK as a Maven dependency to your project, i.e. 
 <dependency>
     <groupId>com.testfabrik.webmate.sdk</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>0.54-SNAPSHOT</version>
+    <version>0.55-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/src/main/java/com/testfabrik/webmate/javasdk/testmgmt/TestMgmtClient.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/testmgmt/TestMgmtClient.java
@@ -282,7 +282,7 @@ public class TestMgmtClient {
             return waitForTestRunCompletion(testRunId, MAX_LONG_WAITING_TIME_MILLIS);
         }
 
-        public TestRunInfo waitForTestRunCompletion(TestRunId testRunId, long maxWaitingTimeInMilliSeconds) {
+        public TestRunInfo waitForTestRunCompletion(TestRunId testRunId, long maxWaitingTimeMillis) {
             long startTime = System.currentTimeMillis();
             TestRunInfo testRunInfo = null;
             try {
@@ -293,7 +293,7 @@ public class TestMgmtClient {
                         testRunInfo.getExecutionStatus() == TestRunExecutionStatus.CREATED ||
                         testRunInfo.getEvaluationStatus() == TestRunEvaluationStatus.PENDING_PASSED ||
                         testRunInfo.getEvaluationStatus() == TestRunEvaluationStatus.PENDING_FAILED) &&
-                        System.currentTimeMillis() - startTime < maxWaitingTimeInMilliSeconds);
+                        System.currentTimeMillis() - startTime < maxWaitingTimeMillis);
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
@@ -386,14 +386,16 @@ public class TestMgmtClient {
     }
 
     /**
-     * Create and start a TestExecution.
+     * Create and start a test execution.
      * This method is blocking:
      * it internally calls a method similar to {@link #waitForTestRunCompletion(TestRunId) waitForTestRunCompletion}
      * to wait until the associated test run is running.
+     * If the test run is not running after the timeout, the method will still return;
+     * to detect this case, you have to check the test run manually.
      *
      * @param spec      The specification metadata for the test execution.
      * @param projectId The id of the project the test execution belongs to.
-     * @return          The returned data, including the test execution id and the id of the associated test run.
+     * @return          The response data, including the test execution id and the id of the associated test run.
      */
     public CreateTestExecutionResponse startExecution(TestExecutionSpec spec, ProjectId projectId) {
         CreateTestExecutionResponse executionAndRun = apiClient.createAndStartTestExecution(projectId, spec);
@@ -405,13 +407,15 @@ public class TestMgmtClient {
     }
 
     /**
-     * Create and start a TestExecution.
+     * Create and start a test execution.
      * This method is blocking:
      * it internally calls a method similar to {@link #waitForTestRunCompletion(TestRunId) waitForTestRunCompletion}
      * to wait until the associated test run is running.
+     * If the test run is not running after the timeout, the method will still return;
+     * to detect this case, you have to check the test run manually.
      *
-     * @param specBuilder A builder providing the required information for that test type, e.g. {@code Story}
-     * @return            The test run associated with the test execution
+     * @param specBuilder A builder providing the required information for that test type, e.g. {@code Story}.
+     * @return            The test run associated with the test execution.
      */
     public TestRun startExecutionWithBuilder(TestExecutionSpecBuilder specBuilder) {
         if (!session.getProjectId().isPresent()) {
@@ -437,10 +441,12 @@ public class TestMgmtClient {
     }
 
     /**
-     * Finish a running TestRun.
+     * Finish a running test run.
      * This method is blocking:
      * it internally calls the {@link #waitForTestRunCompletion(TestRunId) waitForTestRunCompletion} method
      * to wait until the test run is finished.
+     * If the test run does not finish before the timeout, the method will still return;
+     * to detect this case, you have to check the test run manually.
      *
      * @param id     The id of the test run to finish.
      * @param status The status to finish the test run with.
@@ -450,29 +456,33 @@ public class TestMgmtClient {
     }
 
     /**
-     * Finish a running TestRun with message.
+     * Finish a running test run.
      * This method is blocking:
      * it internally calls the {@link #waitForTestRunCompletion(TestRunId) waitForTestRunCompletion} method
      * to wait until the test run is finished.
+     * If the test run does not finish before the timeout, the method will still return;
+     * to detect this case, you have to check the test run manually.
      *
      * @param id     The id of the test run to finish.
      * @param status The status to finish the test run with.
-     * @param msg    The message to finish the test run with.
+     * @param msg    A short message explaining the result of the test run.
      */
     public void finishTestRun(TestRunId id, TestRunEvaluationStatus status, String msg) {
         apiClient.finishTestRun(id, new TestRunFinishData(status, msg));
     }
 
     /**
-     * Finish a running TestRun with message and detail information.
+     * Finish a running test run.
      * This method is blocking:
      * it internally calls the {@link #waitForTestRunCompletion(TestRunId) waitForTestRunCompletion} method
      * to wait until the test run is finished.
+     * If the test run does not finish before the timeout, the method will still return;
+     * to detect this case, you have to check the test run manually.
      *
      * @param id     The id of the test run to finish.
      * @param status The status to finish the test run with.
-     * @param msg    The message to finish the test run with.
-     * @param detail More details for the finish data.
+     * @param msg    A short message explaining the result of the test run.
+     * @param detail Detailed information, e.g. a stack trace.
      */
     public void finishTestRun(TestRunId id, TestRunEvaluationStatus status, String msg, String detail) {
         apiClient.finishTestRun(id, new TestRunFinishData(status, msg, detail));
@@ -486,24 +496,29 @@ public class TestMgmtClient {
     }
 
     /**
-     * Block, until the TestRun goes into a finished state (completed or failed) or timeout occurs (after 10 minutes).
+     * Block until the test run goes into a finished state (completed or failed) or timeout occurs.
+     * The default timeout is 10 minutes.
+     * If the test run does not finish before the timeout, the method will still return;
+     * to detect this case, you have to check the returned test run info manually.
      *
-     * @return the TestRun info of the finished TestRun.
+     * @param id The id of the test run to wait for.
+     * @return   The test run info of the finished test run.
      */
     public TestRunInfo waitForTestRunCompletion(TestRunId id) {
         return apiClient.waitForTestRunCompletion(id);
     }
 
     /**
-     * Block, until the TestRun goes into a finished state (completed or failed) or timeout occurs.
+     * Block until the test run goes into a finished state (completed or failed) or timeout occurs.
+     * If the test run does not finish before the timeout, the method will still return;
+     * to detect this case, you have to check the returned test run info manually.
      *
-     * @param id The ID of the TestRun to wait for
-     * @param maxWaitingTimeInMilliSeconds How long to wait before timeout
-     *
-     * @return the TestRun info of the finished TestRun.
+     * @param id                   The id of the test run to wait for.
+     * @param maxWaitingTimeMillis How long to wait before timeout.
+     * @return                     The test run info of the finished test run.
      */
-    public TestRunInfo waitForTestRunCompletion(TestRunId id, long maxWaitingTimeInMilliSeconds) {
-        return apiClient.waitForTestRunCompletion(id, maxWaitingTimeInMilliSeconds);
+    public TestRunInfo waitForTestRunCompletion(TestRunId id, long maxWaitingTimeMillis) {
+        return apiClient.waitForTestRunCompletion(id, maxWaitingTimeMillis);
     }
 
 }

--- a/src/main/java/com/testfabrik/webmate/javasdk/testmgmt/TestMgmtClient.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/testmgmt/TestMgmtClient.java
@@ -185,6 +185,8 @@ public class TestMgmtClient {
             if (!optHttpResponse.isPresent()) {
                 throw new WebmateApiClientException("Could not finish TestRun. Got no response");
             }
+
+            waitForTestRunCompletion(id);
         }
 
         public List<TestTemplate> getTestTemplates(ProjectId projectId) {

--- a/src/main/java/com/testfabrik/webmate/javasdk/testmgmt/TestMgmtClient.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/testmgmt/TestMgmtClient.java
@@ -299,6 +299,25 @@ public class TestMgmtClient {
             }
             return testRunInfo;
         }
+
+        public TestRunInfo waitForTestRunRunning(TestRunId testRunId) {
+            return waitForTestRunRunning(testRunId, MAX_LONG_WAITING_TIME_MILLIS);
+        }
+
+        public TestRunInfo waitForTestRunRunning(TestRunId testRunId, long maxWaitingTimeInMilliSeconds) {
+            long startTime = System.currentTimeMillis();
+            TestRunInfo testRunInfo = null;
+            try {
+                do {
+                    Thread.sleep(WAITING_POLLING_INTERVAL_MILLIS);
+                    testRunInfo = this.getTestRun(testRunId);
+                } while (testRunInfo.getExecutionStatus() == TestRunExecutionStatus.CREATED &&
+                        System.currentTimeMillis() - startTime < maxWaitingTimeInMilliSeconds);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            return testRunInfo;
+        }
     }
 
     /**
@@ -371,6 +390,7 @@ public class TestMgmtClient {
         if (!executionAndRun.optTestRunId.isPresent()) {
             throw new WebmateApiClientException("Got no testrun id for new execution.");
         }
+        apiClient.waitForTestRunRunning(executionAndRun.optTestRunId.get());
         return executionAndRun;
     }
 

--- a/src/main/java/com/testfabrik/webmate/javasdk/testmgmt/TestMgmtClient.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/testmgmt/TestMgmtClient.java
@@ -385,6 +385,16 @@ public class TestMgmtClient {
         this.apiClient.setTestRunName(testRunId, name);
     }
 
+    /**
+     * Create and start a TestExecution.
+     * This method is blocking:
+     * it internally calls a method similar to {@link #waitForTestRunCompletion(TestRunId) waitForTestRunCompletion}
+     * to wait until the associated test run is running.
+     *
+     * @param spec      The specification metadata for the test execution.
+     * @param projectId The id of the project the test execution belongs to.
+     * @return          The returned data, including the test execution id and the id of the associated test run.
+     */
     public CreateTestExecutionResponse startExecution(TestExecutionSpec spec, ProjectId projectId) {
         CreateTestExecutionResponse executionAndRun = apiClient.createAndStartTestExecution(projectId, spec);
         if (!executionAndRun.optTestRunId.isPresent()) {
@@ -396,8 +406,12 @@ public class TestMgmtClient {
 
     /**
      * Create and start a TestExecution.
+     * This method is blocking:
+     * it internally calls a method similar to {@link #waitForTestRunCompletion(TestRunId) waitForTestRunCompletion}
+     * to wait until the associated test run is running.
      *
      * @param specBuilder A builder providing the required information for that test type, e.g. {@code Story}
+     * @return            The test run associated with the test execution
      */
     public TestRun startExecutionWithBuilder(TestExecutionSpecBuilder specBuilder) {
         if (!session.getProjectId().isPresent()) {
@@ -424,6 +438,12 @@ public class TestMgmtClient {
 
     /**
      * Finish a running TestRun.
+     * This method is blocking:
+     * it internally calls the {@link #waitForTestRunCompletion(TestRunId) waitForTestRunCompletion} method
+     * to wait until the test run is finished.
+     *
+     * @param id     The id of the test run to finish.
+     * @param status The status to finish the test run with.
      */
     public void finishTestRun(TestRunId id, TestRunEvaluationStatus status) {
        apiClient.finishTestRun(id, new TestRunFinishData(status));
@@ -431,6 +451,13 @@ public class TestMgmtClient {
 
     /**
      * Finish a running TestRun with message.
+     * This method is blocking:
+     * it internally calls the {@link #waitForTestRunCompletion(TestRunId) waitForTestRunCompletion} method
+     * to wait until the test run is finished.
+     *
+     * @param id     The id of the test run to finish.
+     * @param status The status to finish the test run with.
+     * @param msg    The message to finish the test run with.
      */
     public void finishTestRun(TestRunId id, TestRunEvaluationStatus status, String msg) {
         apiClient.finishTestRun(id, new TestRunFinishData(status, msg));
@@ -438,6 +465,14 @@ public class TestMgmtClient {
 
     /**
      * Finish a running TestRun with message and detail information.
+     * This method is blocking:
+     * it internally calls the {@link #waitForTestRunCompletion(TestRunId) waitForTestRunCompletion} method
+     * to wait until the test run is finished.
+     *
+     * @param id     The id of the test run to finish.
+     * @param status The status to finish the test run with.
+     * @param msg    The message to finish the test run with.
+     * @param detail More details for the finish data.
      */
     public void finishTestRun(TestRunId id, TestRunEvaluationStatus status, String msg, String detail) {
         apiClient.finishTestRun(id, new TestRunFinishData(status, msg, detail));

--- a/src/main/java/com/testfabrik/webmate/javasdk/testmgmt/TestRun.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/testmgmt/TestRun.java
@@ -37,26 +37,39 @@ public class TestRun {
     }
 
     /**
-     * Finish TestRun.
+     * Finish the test run.
+     * This method is blocking:
+     * it internally calls the {@link #waitForCompletion()} waitForCompletion} method
+     * to wait until the test run is finished.
      *
-     * @param msg Short message explaining the result of the test run.
-     * @param detail Detailed information, e.g. stack trace.
+     * @param status The status to finish the test run with.
+     * @param msg    A short message explaining the result of the test run.
+     * @param detail Detailed information, e.g. a stack trace.
      */
     public void finish(TestRunEvaluationStatus status, String msg, String detail) {
         this.session.testMgmt.finishTestRun(id, status, msg, detail);
     }
 
     /**
-     * Finish TestRun.
+     * Finish the test run.
+     * This method is blocking:
+     * it internally calls the {@link #waitForCompletion()} waitForCompletion} method
+     * to wait until the test run is finished.
      *
-     * @param msg Short message explaining the result of the test run.
+     * @param status The status to finish the test run with.
+     * @param msg    A short message explaining the result of the test run.
      */
     public void finish(TestRunEvaluationStatus status, String msg) {
         this.session.testMgmt.finishTestRun(id, status, msg);
     }
 
     /**
-     * Finish TestRun.
+     * Finish the test run.
+     * This method is blocking:
+     * it internally calls the {@link #waitForCompletion()} waitForCompletion} method
+     * to wait until the test run is finished.
+     *
+     * @param status The status to finish the test run with.
      */
     public void finish(TestRunEvaluationStatus status) {
         this.session.testMgmt.finishTestRun(id, status);

--- a/src/main/java/com/testfabrik/webmate/javasdk/testmgmt/TestRun.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/testmgmt/TestRun.java
@@ -39,8 +39,10 @@ public class TestRun {
     /**
      * Finish the test run.
      * This method is blocking:
-     * it internally calls the {@link #waitForCompletion()} waitForCompletion} method
+     * it internally calls the {@link #waitForCompletion() waitForCompletion} method
      * to wait until the test run is finished.
+     * If the test run does not finish before the timeout, the method will still return;
+     * to detect this case, you have to check the test run manually.
      *
      * @param status The status to finish the test run with.
      * @param msg    A short message explaining the result of the test run.
@@ -53,8 +55,10 @@ public class TestRun {
     /**
      * Finish the test run.
      * This method is blocking:
-     * it internally calls the {@link #waitForCompletion()} waitForCompletion} method
+     * it internally calls the {@link #waitForCompletion() waitForCompletion} method
      * to wait until the test run is finished.
+     * If the test run does not finish before the timeout, the method will still return;
+     * to detect this case, you have to check the test run manually.
      *
      * @param status The status to finish the test run with.
      * @param msg    A short message explaining the result of the test run.
@@ -66,8 +70,10 @@ public class TestRun {
     /**
      * Finish the test run.
      * This method is blocking:
-     * it internally calls the {@link #waitForCompletion()} waitForCompletion} method
+     * it internally calls the {@link #waitForCompletion() waitForCompletion} method
      * to wait until the test run is finished.
+     * If the test run does not finish before the timeout, the method will still return;
+     * to detect this case, you have to check the test run manually.
      *
      * @param status The status to finish the test run with.
      */
@@ -76,10 +82,12 @@ public class TestRun {
     }
 
     /**
-     * Block, until the TestRun goes into a finished state (completed or failed) or timeout occurs (after 10 minutes).
+     * Block until the test run goes into a finished state (completed or failed) or timeout occurs.
+     * The default timeout is 10 minutes.
+     * If the test run does not finish before the timeout, the method will still return;
+     * to detect this case, you have to check the returned test run info manually.
      *
-     * @return the TestRun info of the finished TestRun.
-     *
+     * @return The test run info of the finished test run.
      */
     public TestRunInfo waitForCompletion() {
         return this.session.testMgmt.waitForTestRunCompletion(this.id);


### PR DESCRIPTION
The SDK creates and finishes test runs asynchronously. It used to do this in the background. This led to bugs: when you create a test run and do a Selenium action before the test run creation is complete, the Selenium action does not show up as part of the test run.

With this bug fix, the SDK waits for the asynchronous creation and completion of test runs to finish before returning control. This way, Selenium actions will no longer go missing.