### PR TITLE
WMKNBN-9643: Add config route for biometrics sim

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.55] - 2024-02-02
+### New Features
+- A method in the device client to configure the simulation of biometric authentication
+
 ## [0.54] - 2024-01-16
 ### Fixes
 - Wait for test run creation/completion to finish

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## [0.55] - 2024-02-02
+## [0.55] - 2024-02-05
 ### New Features
 - A method in the device client to configure the simulation of biometric authentication
+- Methods to retrieve the browser session info (including the device id) for a running Selenium test
 
 ## [0.54] - 2024-01-16
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This release is also distributed via Maven Central. Just include the following d
 <dependency>
     <groupId>com.testfabrik.webmate.sdk</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>0.54</version>
+    <version>0.55</version>
 </dependency>
 ```
 
@@ -39,7 +39,7 @@ After that, you can include the SDK as a Maven dependency to your project, i.e. 
 <dependency>
     <groupId>com.testfabrik.webmate.sdk</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>0.55-SNAPSHOT</version>
+    <version>0.56-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionClient.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionClient.java
@@ -76,6 +76,9 @@ public class BrowserSessionClient {
         private final static UriTemplate terminateBrowsersessionTemplate =
                 new UriTemplate("/browsersession/${browserSessionId}");
 
+        private final static UriTemplate retrieveBrowserSessionInfoTemplate =
+                new UriTemplate("/browsersession/${browserSessionId}/info");
+
 
         /**
          * Creates an webmate api client.
@@ -142,6 +145,11 @@ public class BrowserSessionClient {
         public void finishAction(BrowserSessionId expeditionId, FinishStoryActionAddArtifactData art) {
             Map<String, String>  params = ImmutableMap.of("expeditionId", expeditionId.getValueAsString());
             sendPOST(addArtifactTemplate, params, JsonUtils.getJsonFromData(art)).getOptHttpResponse();
+        }
+
+        public BrowserSessionInfo getBrowserSessionInfo(BrowserSessionId id) {
+            Optional<HttpResponse> r = sendGET(retrieveBrowserSessionInfoTemplate, ImmutableMap.of("browserSessionId", id.toString())).getOptHttpResponse();
+            return HttpHelpers.getObjectFromJsonEntity(r.get(), BrowserSessionInfo.class);
         }
     }
 
@@ -377,6 +385,15 @@ public class BrowserSessionClient {
     public boolean terminateBrowsersession(BrowserSessionId browserSessionId) {
         LOG.debug("Trying to terminate Browsersession with id ["+ browserSessionId +"]");
         return apiClient.terminateSession(browserSessionId);
+    }
+
+    /**
+     * Retrieves info for this BrowserSession
+     * @param id The id of the BrowserSession that info should be retrieved for
+     * @return BrowserSessionInfo for this BrowserSession
+     */
+    public BrowserSessionInfo getBrowserSessionInfo(BrowserSessionId id) {
+        return apiClient.getBrowserSessionInfo(id);
     }
 
 }

--- a/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionInfo.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionInfo.java
@@ -1,0 +1,54 @@
+package com.testfabrik.webmate.javasdk.browsersession;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.testfabrik.webmate.javasdk.devices.DeviceId;
+import org.joda.time.DateTime;
+
+import java.util.Optional;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BrowserSessionInfo {
+
+    private BrowserSessionId id;
+    private Optional<DateTime> optStart;
+    private Optional<DateTime> optEnd;
+    private Optional<DeviceId> optDeviceId;
+
+    public BrowserSessionInfo() {}
+
+    public BrowserSessionInfo(BrowserSessionId id, Optional<DateTime> optStart, Optional<DateTime> optEnd, Optional<DeviceId> optDeviceId) {
+        this.id = id;
+        this.optStart = optStart;
+        this.optEnd = optEnd;
+        this.optDeviceId = optDeviceId;
+    }
+
+    public BrowserSessionId getId() {
+        return id;
+    }
+
+    public Optional<DateTime> getOptStart() {
+        return optStart;
+    }
+
+    public Optional<DateTime> getOptEnd() {
+        return optEnd;
+    }
+
+    public Optional<DeviceId> getOptDeviceId() {
+        return optDeviceId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BrowserSessionInfo that = (BrowserSessionInfo) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionRef.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionRef.java
@@ -101,6 +101,14 @@ public class BrowserSessionRef {
         return session.browserSession.terminateBrowsersession(browserSessionId);
     }
 
+    /**
+     * Retrieves info for this BrowserSession
+     * @return BrowserSessionInfo for this BrowserSession
+     */
+    public BrowserSessionInfo getBrowserSessionInfo() {
+        return session.browserSession.getBrowserSessionInfo(browserSessionId);
+    }
+
 
     @Override
     public int hashCode() {

--- a/src/main/java/com/testfabrik/webmate/javasdk/devices/CapabilityConstants.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/devices/CapabilityConstants.java
@@ -3,4 +3,6 @@ package com.testfabrik.webmate.javasdk.devices;
 class CapabilityConstants {
     public static final String SIMULATE_CAMERA = "sensorsimulation.simulateCamera";
     public static final String MEDIA_SETTINGS = "settings.media";
+    public static final String SIMULATE_BIOMETRICS = "sensorsimulation.simulateBiometrics";
+    public static final String ACCEPT_BIOMETRICS = "sensorsimulation.acceptBiometricAuthentication";
 }

--- a/src/main/java/com/testfabrik/webmate/javasdk/devices/DeviceClient.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/devices/DeviceClient.java
@@ -60,6 +60,8 @@ public class DeviceClient {
 
         private final static UriTemplate setCameraSimulation = new UriTemplate("/device/devices/${deviceId}/capabilities");
 
+        private final static UriTemplate setBiometricsSimulation = new UriTemplate("/device/devices/${deviceId}/capabilities");
+
         public DeviceApiClient(WebmateAuthInfo authInfo, WebmateEnvironment environment) {
             super(authInfo, environment);
         }
@@ -169,6 +171,11 @@ public class DeviceClient {
             simulateCameraNode.put("selectedImage", selectedImageId);
             Map<String, Object> params = ImmutableMap.of(CapabilityConstants.SIMULATE_CAMERA, simulateCameraNode, CapabilityConstants.MEDIA_SETTINGS, imagePool.toJson());
             sendPOST(setCameraSimulation, ImmutableMap.of("deviceId", deviceId.toString()), JsonUtils.getJsonFromData(params));
+        }
+
+        public void setBiometricsSimulation(DeviceId deviceId, boolean simulate, boolean accept) {
+            Map<String, Boolean> params = ImmutableMap.of(CapabilityConstants.SIMULATE_BIOMETRICS, simulate, CapabilityConstants.ACCEPT_BIOMETRICS, accept);
+            sendPOST(setBiometricsSimulation, ImmutableMap.of("deviceId", deviceId.toString()), JsonUtils.getJsonFromData(params));
         }
 
         private DeviceDTO waitForProperties(DeviceId deviceId, Map<String, JsonNode> expectedProperties) {
@@ -409,6 +416,19 @@ public class DeviceClient {
      */
     public void setCameraSimulation(DeviceId deviceId, ImageId selectedImageId, boolean simulate) {
         setCameraSimulation(deviceId, selectedImageId, simulate, new ImagePool(selectedImageId));
+    }
+
+    /**
+     * Configure the biometrics simulation on a device.
+     *
+     * @param deviceId             The device id of the device.
+     * @param simulateBiometrics   True if the biometrics simulation should be enabled, false otherwise.
+     * @param acceptAuthentication True if the device should immediately accept the simulated authentication,
+     *                             false if the device should immediately reject the simulated authentication.
+     *                             Note that this flag only has any effect if <code>simulateBiometrics</code> is true.
+     */
+    public void setBiometricsSimulation(DeviceId deviceId, boolean simulateBiometrics, boolean acceptAuthentication) {
+        this.apiClient.setBiometricsSimulation(deviceId, simulateBiometrics, acceptAuthentication);
     }
 
     /**


### PR DESCRIPTION
There is an undocumented API route in the webmate backend to configure device capabilities. The device capabilities include the capability to simulate biometric authentication. This pull request adds a method to the SDK that encapsulates an API call to configure that capability.