### PR TITLE
WMKNBN-10107: Fix handling of multiple expeditions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.56] - 2024-04-25
+### Fixes
+- Deprecate `terminateBrowsersession` whose backend route has been removed
+- Add methods that accept an explicit expedition (browser session) id, rather than relying on a unique implicit one
+- Replace exceptions with warnings when an implicit expedition id is not unique
+
 ## [0.55] - 2024-02-05
 ### New Features
 - A method in the device client to configure the simulation of biometric authentication

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This release is also distributed via Maven Central. Just include the following d
 <dependency>
     <groupId>com.testfabrik.webmate.sdk</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>0.55</version>
+    <version>0.56</version>
 </dependency>
 ```
 
@@ -39,7 +39,7 @@ After that, you can include the SDK as a Maven dependency to your project, i.e. 
 <dependency>
     <groupId>com.testfabrik.webmate.sdk</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>0.56-SNAPSHOT</version>
+    <version>0.57-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/src/main/java/com/testfabrik/webmate/javasdk/WebmateAPISession.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/WebmateAPISession.java
@@ -17,6 +17,8 @@ import com.testfabrik.webmate.javasdk.testmgmt.ApplicationModelId;
 import com.testfabrik.webmate.javasdk.testmgmt.TestMgmtClient;
 import com.testfabrik.webmate.javasdk.testmgmt.TestSessionId;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,6 +28,8 @@ import java.util.UUID;
  * WebmateSession
  */
 public class WebmateAPISession {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WebmateAPISession.class);
 
     public final WebmateAuthInfo authInfo;
     public final WebmateEnvironment environment;
@@ -109,13 +113,20 @@ public class WebmateAPISession {
 
     /**
      * Check if there is only one associated Expedition / BrowserSession and return it.
+     * If there are none, log a warning and return null.
+     * If there are more than one, log a warning and return the newest one.
      */
     public BrowserSessionId getOnlyAssociatedExpedition() {
-        if (associatedExpeditions.size() != 1) {
-            throw new WebmateApiClientException("Expected exactly one active Expedition (e.g. BrowserSession) in WebmateSession, but there are " +
-                    associatedExpeditions.size());
+        switch (associatedExpeditions.size()) {
+        case 0:
+            LOG.warn("Expected exactly one active Expedition (e.g. BrowserSession), but there are none; returning null");
+            return null;
+        case 1:
+            return associatedExpeditions.get(0);
+        default:
+            LOG.warn("Expected exactly one active Expedition (e.g. BrowserSession), but there are more; returning the newest one");
+            return associatedExpeditions.get(associatedExpeditions.size() - 1);
         }
-        return associatedExpeditions.get(0);
     }
 
     public List<TestSessionId> getAssociatedTestSessions() {

--- a/src/main/java/com/testfabrik/webmate/javasdk/WebmateAPISession.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/WebmateAPISession.java
@@ -276,21 +276,50 @@ public class WebmateAPISession {
     }
 
     /**
-     * Start an action of type "story" with the given name.
+     * Start an action for the given expedition with the given name.
+     */
+    public void startAction(BrowserSessionId expeditionId, String actionName) {
+        this.browserSession.startAction(expeditionId, actionName);
+    }
+
+    /**
+     * Start an action with the given name.
+     * The expedition of the action is supplied using {@link WebmateAPISession#getOnlyAssociatedExpedition}.
+     * If it returns null, log a warning and do nothing.
      */
     public void startAction(String actionName) {
         this.browserSession.startAction(actionName);
     }
 
     /**
-     * Finish the current action with successful result.
+     * Finish the newest action of the given expedition.
+     * If there is no active action, log a warning and do nothing.
+     */
+    public void finishAction(BrowserSessionId expeditionId) {
+        this.browserSession.finishAction(expeditionId);
+    }
+
+    /**
+     * Finish the newest action of the newest expedition.
+     * The expedition of the action is supplied using {@link WebmateAPISession#getOnlyAssociatedExpedition}.
+     * If it returns null, or if there is no active action, log a warning and do nothing.
      */
     public void finishAction() {
         this.browserSession.finishAction();
     }
 
     /**
-     * Finish the current action with successful result.
+     * Fail the newest action of the given expedition with the given message.
+     * If there is no active action, log a warning and do nothing.
+     */
+    public void finishActionAsFailure(BrowserSessionId expeditionId, String message) {
+        this.browserSession.finishActionAsFailure(expeditionId, message);
+    }
+
+    /**
+     * Fail the newest action of the newest expedition with the given message.
+     * The expedition of the action is supplied using {@link WebmateAPISession#getOnlyAssociatedExpedition}.
+     * If it returns null, or if there is no active action, log a warning and do nothing.
      */
     public void finishActionAsFailure(String message) {
         this.browserSession.finishActionAsFailure(message);

--- a/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionClient.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionClient.java
@@ -170,16 +170,12 @@ public class BrowserSessionClient {
      * @throws WebmateApiClientException if an error occurs while requesting state extraction or if the timeout is exceeded.
      */
     public BrowserSessionStateId createState(String matchingId, BrowserSessionStateExtractionConfig browserSessionStateExtractionConfig) {
-        List<BrowserSessionId> associatedExpeditions = session.getAssociatedExpeditions();
-        if (associatedExpeditions.size() != 1) {
+        BrowserSessionId browserSessionId = session.getOnlyAssociatedExpedition();
+        if (browserSessionId == null) {
             throw new WebmateApiClientException("If createState is called without browsersession id, there must be only one " +
-                    "BrowserSession associated with the API session (to be able to identify the correct one) " +
-                    "but currently there are " + associatedExpeditions.size());
+                    "BrowserSession associated with the API session (to be able to identify the correct one)");
         }
-
-        BrowserSessionId browserSessionId = associatedExpeditions.get(0);
         LOG.info("Creating state for browsersession " + browserSessionId);
-
         return createState(browserSessionId, matchingId, browserSessionStateExtractionConfig);
     }
 
@@ -191,16 +187,12 @@ public class BrowserSessionClient {
      * @throws WebmateApiClientException if an error occurs while requesting state extraction or if the timeout is exceeded.
      */
     public BrowserSessionStateId createState(String matchingId) {
-        List<BrowserSessionId> associatedExpeditions = session.getAssociatedExpeditions();
-        if (associatedExpeditions.size() != 1) {
+        BrowserSessionId browserSessionId = session.getOnlyAssociatedExpedition();
+        if (browserSessionId == null) {
             throw new WebmateApiClientException("If createState is called without browsersession id, there must be only one " +
-                    "BrowserSession associated with the API session (to be able to identify the correct one) " +
-                    "but currently there are " + associatedExpeditions.size());
+                    "BrowserSession associated with the API session (to be able to identify the correct one)");
         }
-
-        BrowserSessionId browserSessionId = associatedExpeditions.get(0);
         LOG.info("Creating state for browsersession " + browserSessionId);
-
         return createState(browserSessionId, matchingId);
     }
 

--- a/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionClient.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionClient.java
@@ -73,9 +73,6 @@ public class BrowserSessionClient {
         private final static UriTemplate addArtifactTemplate =
                 new UriTemplate("/browsersession/${expeditionId}/artifacts");
 
-        private final static UriTemplate terminateBrowsersessionTemplate =
-                new UriTemplate("/browsersession/${browserSessionId}");
-
         private final static UriTemplate retrieveBrowserSessionInfoTemplate =
                 new UriTemplate("/browsersession/${browserSessionId}/info");
 
@@ -100,28 +97,6 @@ public class BrowserSessionClient {
          */
         public BrowserSessionApiClient(WebmateAuthInfo authInfo, WebmateEnvironment environment, HttpClientBuilder httpClientBuilder) {
             super(authInfo, environment, httpClientBuilder);
-        }
-
-        /**
-         * Tries to terminate a Browsersession. Will return whether the process was successful or not.
-         *
-         * @param browserSessionId The id of the session that should be terminated
-         * @return true, if the Browersession was terminated successfully.
-         */
-        public boolean terminateSession(BrowserSessionId browserSessionId) {
-            Optional<HttpResponse> r = sendPOST(terminateBrowsersessionTemplate, ImmutableMap.of("browserSessionId", browserSessionId.toString()), "terminate").getOptHttpResponse();
-            boolean stopped = false;
-            if (!r.isPresent()){
-                throw new WebmateApiClientException("Could not stop Browsersession. Got no response");
-            }
-            else {
-                try {
-                    stopped = EntityUtils.toString(r.get().getEntity()).equals("true");
-                } catch (IOException e) {
-                    LOG.error("Failed to read response:", e);
-                }
-            }
-            return stopped;
         }
 
         /**
@@ -377,14 +352,14 @@ public class BrowserSessionClient {
     }
 
     /**
-     * Terminate the given BrowserSession
-     *
-     * @param browserSessionId The Id for the BrowserSession that is supposed to be terminated
-     * @return true if the Browsersession was successfully terminated
+     * @deprecated
+     * This method is deprecated.
+     * It is no longer possible to manually terminate browser sessions.
+     * @return False (because no browser session is being terminated successfully).
      */
     public boolean terminateBrowsersession(BrowserSessionId browserSessionId) {
-        LOG.debug("Trying to terminate Browsersession with id ["+ browserSessionId +"]");
-        return apiClient.terminateSession(browserSessionId);
+        LOG.warn("Deprecated method terminateBrowsersession used: it is no longer possible to manually terminate browser sessions");
+        return false;
     }
 
     /**

--- a/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionId.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionId.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 public class BrowserSessionId {
 
-    private UUID value;
+    private final UUID value;
 
 
     @JsonCreator

--- a/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionRef.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionRef.java
@@ -93,9 +93,10 @@ public class BrowserSessionRef {
     }
 
     /**
-     * Terminates the BrowserSession.
-     *
-     * @return true if the BrowserSession was successfully terminated
+     * @deprecated
+     * This method is deprecated.
+     * It is no longer possible to manually terminate browser sessions.
+     * @return False (because no browser session is being terminated successfully).
      */
     public boolean terminateSession() {
         return session.browserSession.terminateBrowsersession(browserSessionId);

--- a/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionRef.java
+++ b/src/main/java/com/testfabrik/webmate/javasdk/browsersession/BrowserSessionRef.java
@@ -38,58 +38,54 @@ public class BrowserSessionRef {
     }
 
     /**
-     * Start custom action with given name. If there is another action already active, this action will be a
-     * child action of that one.
+     * Start a custom action with the given name.
+     * If there is another action already active, this action will be a child action of that one.
      */
     public void startAction(String actionName) {
-        session.browserSession.startAction(actionName);
+        session.browserSession.startAction(browserSessionId, actionName);
     }
 
     /**
-     * Wrap the given action (lambda) in an Action with the given name. The action can be
-     * closed explicitly with the ActionDelegate argument provided to the lambda. It also
-     * implicitly finishes as successful or an error if an exception is throws within the lambda.
-     *
-     * @param actionName Name of action
-     * @param actionFunc function executed within action.
-     * @param <T> Return value of inner code.
-     * @return Returned value of lambda
+     * Wrap the given action lambda function in a custom action with the given name.
+     * The action can be closed explicitly with the ActionDelegate argument provided to the lambda.
+     * It also implicitly finishes as successful or an error if an exception is thrown within the lambda.
+     * @return The return value of the lambda function, null on failure.
      */
     public <T> T withAction(String actionName, BrowserSessionClient.ActionFunc<T> actionFunc) {
-        return session.browserSession.withAction(actionName, actionFunc);
+        return session.browserSession.withAction(browserSessionId, actionName, actionFunc);
     }
 
     /**
-     * Wrap the given action (lambda) in an Action with the given name. The action can be
-     * closed explicitly with the ActionDelegate argument provided to the lambda. It also
-     * implicitly finishes as successful or an error if an exception is throws within the lambda.
-     *
-     * @param actionName Name of action
-     * @param actionFunc function executed within action.
+     * Wrap the given action lambda function in a custom action with the given name.
+     * The action can be closed explicitly with the ActionDelegate argument provided to the lambda.
+     * It also implicitly finishes as successful or an error if an exception is thrown within the lambda.
      */
     public void withAction(String actionName, BrowserSessionClient.ActionFuncVoid actionFunc) {
-        session.browserSession.withAction(actionName, actionFunc);
+        session.browserSession.withAction(browserSessionId, actionName, actionFunc);
     }
 
     /**
-     * Finish the current active custom action as a success.
+     * Finish the newest custom action.
+     * If there is no active action, log a warning and do nothing.
      */
     public void finishAction() {
-        session.browserSession.finishAction();
+        session.browserSession.finishAction(browserSessionId);
     }
 
     /**
-     * Finish the currently active custom action successfully with message.
+     * Finish the newest custom action with the given message.
+     * If there is no active action, log a warning and do nothing.
      */
     public void finishAction(String successMessage) {
-        session.browserSession.finishAction(successMessage);
+        session.browserSession.finishAction(browserSessionId, successMessage);
     }
 
     /**
-     * Finish the currently active custom action and mark as failed with the given message.
+     * Fail the newest custom action with the given message.
+     * If there is no active action, log a warning and do nothing.
      */
     public void finishActionAsFailure(String errorMessage) {
-        session.browserSession.finishActionAsFailure(errorMessage);
+        session.browserSession.finishActionAsFailure(browserSessionId, errorMessage);
     }
 
     /**


### PR DESCRIPTION
Multiple methods rely on the assumption that there is only one active expedition (browser session). But there can be multiple at the same time. This branch

- makes sure that actions from different expeditions don't get mixed,
- adds methods that take an explicit expedition id instead of trying to find a unique implicit one,
- makes sure that methods log warnings instead of throwing exceptions when an implicit expedition id is not unique.

Minor bugs are fixed along the way.